### PR TITLE
Remove reference to CssBaseline

### DIFF
--- a/docs/dapps/project/app.md
+++ b/docs/dapps/project/app.md
@@ -18,7 +18,6 @@ The role of this component is to wrap the main panel component `<MainPanel />` w
 function App() {
   return (
     <div className="App">
-      <CssBaseline />
       <SettingsProvider>
         <TaquitoProvider>
           <BeaconProvider>
@@ -32,3 +31,4 @@ function App() {
   );
 }
 ```
+


### PR DESCRIPTION
Alternatively, you could include something like: to use css baseline, install material ui with  `npm install @mui/material @emotion/react @emotion/styled` and include the following import
`import { CssBaseline } from '@mui/material'`