### PR TITLE
Update syntax highlighter to catch both types of comments

### DIFF
--- a/src/theme/prism-archetype.js
+++ b/src/theme/prism-archetype.js
@@ -1,7 +1,18 @@
 (function (Prism) {
 
 	Prism.languages.archetype = {
-		'comment': /\/\*[\s\S]*?\*\//,
+		'comment': [
+			{
+				pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,
+				lookbehind: true,
+				greedy: true
+			},
+			{
+				pattern: /(^|[^\\:])\/\/.*/,
+				lookbehind: true,
+				greedy: true
+			}
+		],
 		'string': [
 			{
 				pattern: /"(?:\\.|[^\\\r\n"])*"/,


### PR DESCRIPTION
Archetype comments are formatted like c-like languages, so you can have single-line comments that start with `//` or multi-line comments within `/* ... */`. The Prism rule in this formatter catches only multiline comments. This PR adds single-line comments. I stole the code from the clike formatter here: https://github.com/PrismJS/prism/blob/master/components/prism-clike.js.

Without this change, the comments in https://github.com/completium/archetype-docs/pull/26 look like this:
<img width="466" alt="Screenshot 2024-02-21 at 9 15 20 AM" src="https://github.com/completium/archetype-docs/assets/6494785/7b727275-b616-4944-b79a-dd9dcf5e051c">
